### PR TITLE
Ensure CSV money parsing is DuckDB-safe

### DIFF
--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -3,6 +3,7 @@ from fastapi.responses import HTMLResponse
 import csv
 import io
 from datetime import datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from db import get_db
 
 router = APIRouter()
@@ -35,24 +36,79 @@ def upload_page():
 
 @router.post("/upload")
 def upload_csv(file: UploadFile = File(...)):
-    contents = file.file.read().decode("utf-8")
-    reader = csv.DictReader(io.StringIO(contents))
+    contents_bytes = file.file.read()
+
+    try:
+        contents = contents_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return {
+            "success": False,
+            "error": "File must be UTF-8 encoded CSV"
+        }
+
+    reader = csv.DictReader(io.StringIO(contents, newline=""))
+
+    required_columns = {"Date", "Description", "Amount", "Balance"}
+    if not reader.fieldnames:
+        return {
+            "success": False,
+            "error": "CSV is missing headers"
+        }
+
+    missing_columns = sorted(required_columns - set(reader.fieldnames))
+    if missing_columns:
+        return {
+            "success": False,
+            "error": f"CSV is missing required columns: {', '.join(missing_columns)}"
+        }
 
     conn = get_db()
 
     inserted = 0
     skipped = 0
+    invalid = 0
+
+    def parse_money(value: str):
+        if value is None:
+            raise ValueError("missing money value")
+
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("empty money value")
+
+        is_negative = normalized.startswith("(") and normalized.endswith(")")
+        normalized = normalized.replace("$", "").replace(",", "")
+
+        if is_negative:
+            normalized = normalized[1:-1]
+
+        try:
+            amount = Decimal(normalized).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        except InvalidOperation as exc:
+            raise ValueError("invalid money value") from exc
+
+        return -amount if is_negative else amount
 
     for row in reader:
+        try:
+            raw_date = (row.get("Date") or "").strip()
+            raw_description = (row.get("Description") or "").strip()
+            raw_amount = row.get("Amount")
+            raw_balance = row.get("Balance")
 
-        # Normalize
-        date_obj = datetime.strptime(row["Date"], "%m/%d/%Y")
-        iso_date = date_obj.strftime("%Y-%m-%d")
+            if not raw_date or not raw_description:
+                raise ValueError("missing required row values")
 
-        amount = float(row["Amount"].replace("$", "").replace(",", ""))
+            # Normalize
+            date_obj = datetime.strptime(raw_date, "%m/%d/%Y")
+            iso_date = date_obj.strftime("%Y-%m-%d")
 
-        description = row["Description"].strip()
-        balance = float(row["Balance"].replace("$", "").replace(",", ""))
+            amount = parse_money(raw_amount)
+            balance = parse_money(raw_balance)
+            description = raw_description
+        except (ValueError, TypeError):
+            invalid += 1
+            continue
 
         # Deduplicate
         exists = conn.execute("""
@@ -80,7 +136,8 @@ def upload_csv(file: UploadFile = File(...)):
     return {
         "success": True,
         "inserted": inserted,
-        "skipped": skipped
+        "skipped": skipped,
+        "invalid": invalid
     }
 
 


### PR DESCRIPTION
### Motivation
- Ensure CSV money values match DuckDB `DECIMAL(10,2)` scale so dedupe checks and inserts behave predictably.
- Make CSV ingestion more robust against encoding issues, malformed rows, and missing headers.

### Description
- Decode uploads with `utf-8-sig` and return a clear error when decoding fails, and validate required headers `Date`, `Description`, `Amount`, and `Balance` before processing.
- Add `parse_money` that uses `Decimal` and `quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)` to normalize monetary values (handles `$`, `,`, and parenthesized negatives) so values have exactly 2 decimal places before DB operations.
- Add per-row defensive parsing that skips malformed rows, tracks an `invalid` counter, and preserves previous dedupe logic using the quantized `Decimal` values.
- Update return payload to include `invalid` alongside `inserted` and `skipped`.

### Testing
- Compiled `routes/transactions.py` with `python -m compileall routes/transactions.py` and it completed successfully.
- Ran a smoke ingestion test with a sample CSV containing `"$3.456","$100.129"` and a malformed row `abc`, and observed `{"success": True, "inserted": 1, "skipped": 0, "invalid": 1}`; the DB row was stored as `Decimal('3.46')` and `Decimal('100.13')`, confirming rounding and DuckDB compatibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a215d372c832db4bce91f2388d0ae)