### PR TITLE
sprint 6 - category automation

### DIFF
--- a/repositories/category_rules_repository.py
+++ b/repositories/category_rules_repository.py
@@ -1,0 +1,94 @@
+from db import get_db
+
+
+def get_all_category_rules(conn=None):
+    """
+    Return all category rules sorted by id (priority).
+
+    Args:
+        conn: Optional database connection. If not provided, opens a new one.
+
+    Returns:
+        List of rule dicts with 'id', 'pattern', and 'category' keys.
+
+    Repository-level function: no rule evaluation logic.
+    """
+    own_conn = False
+    if conn is None:
+        conn = get_db()
+        own_conn = True
+
+    try:
+        rows = conn.execute("""
+            SELECT id, pattern, category
+            FROM category_rules
+            ORDER BY id
+        """).fetchall()
+
+        rules = [
+            {
+                "id": r[0],
+                "pattern": r[1],
+                "category": r[2]
+            }
+            for r in rows
+        ]
+
+        return rules
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def get_rule_by_id(conn, rule_id):
+    """
+    Return a single rule by ID.
+
+    Args:
+        conn: Database connection.
+        rule_id: ID of the rule to fetch.
+
+    Returns:
+        Rule dict or None if not found.
+    """
+    row = conn.execute(
+        "SELECT id, pattern, category FROM category_rules WHERE id = ?",
+        (rule_id,)
+    ).fetchone()
+
+    if row:
+        return {
+            "id": row[0],
+            "pattern": row[1],
+            "category": row[2]
+        }
+    return None
+
+
+def add_category_rule(conn, pattern, category):
+    """
+    Insert a new category rule.
+
+    Args:
+        conn: Database connection.
+        pattern: Pattern string to match.
+        category: Category to assign on match.
+    """
+    conn.execute(
+        "INSERT INTO category_rules (pattern, category) VALUES (?, ?)",
+        (pattern, category)
+    )
+
+
+def delete_rule(conn, rule_id):
+    """
+    Delete a rule by ID.
+
+    Args:
+        conn: Database connection.
+        rule_id: ID of the rule to delete.
+    """
+    conn.execute(
+        "DELETE FROM category_rules WHERE id = ?",
+        (rule_id,)
+    )

--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -7,13 +7,10 @@ from services.csv_ingest_service import ingest_csv
 from services.transaction_service import (
     get_all_transactions,
     update_transaction_category,
+    add_transaction,
+    reclassify_all_transactions,
 )
 from repositories.accounts_repository import get_or_create_account
-from services.transaction_service import (
-    get_all_transactions,
-    update_transaction_category,
-    add_transaction,
-)
 
 router = APIRouter()
 
@@ -111,3 +108,17 @@ def add_manual_transaction(tx: ManualTransaction):
         raise HTTPException(status_code=400, detail=f"Insert failed: {e}")
 
     return {"success": True, "message": "Transaction added"}
+
+
+# -------------------------
+# RECLASSIFY TRANSACTIONS
+# -------------------------
+
+@router.post("/transactions/reclassify")
+def reclassify():
+    """Re-apply category rules to all transactions deterministically.
+
+    Returns count of transactions updated.
+    """
+    updated_count = reclassify_all_transactions()
+    return {"success": True, "updated": updated_count}

--- a/services/category_rule_engine.py
+++ b/services/category_rule_engine.py
@@ -1,0 +1,46 @@
+"""
+Category Rule Engine — Deterministic Rule-Based Category Assignment
+
+Pure functions for evaluating transaction descriptions against a sorted rule set.
+No database access; no side effects.
+"""
+
+
+def evaluate_category(description: str, rules: list) -> str | None:
+    """
+    Deterministically evaluate a transaction description against sorted rules.
+
+    Args:
+        description: Transaction description to match against rules.
+        rules: List of rule dicts with 'pattern' and 'category' keys.
+               MUST be explicitly sorted by priority BEFORE calling.
+
+    Returns:
+        Matched category (str) or None if no rule matches.
+
+    Pure function: same inputs → same output, no side effects.
+    """
+    if not description or not rules:
+        return None
+
+    description_lower = description.lower()
+
+    for rule in rules:
+        pattern = rule.get("pattern", "").lower()
+        if not pattern:
+            continue
+
+        # Simple substring match (case-insensitive)
+        if pattern in description_lower:
+            return rule.get("category")
+
+    return None
+
+
+def apply_rules_to_description(description: str, rules: list) -> str | None:
+    """
+    Alias for evaluate_category.
+    
+    Convenience function name for callers that prefer explicit wording.
+    """
+    return evaluate_category(description, rules)

--- a/services/transaction_service.py
+++ b/services/transaction_service.py
@@ -3,7 +3,10 @@ from repositories.transactions_repository import (
     get_all_transactions as repo_get_all_transactions,
     update_category as repo_update_category,
     insert_transaction as repo_insert_transaction,
+    get_transaction_by_id as repo_get_transaction_by_id,
 )
+from repositories.category_rules_repository import get_all_category_rules
+from services.category_rule_engine import evaluate_category
 
 
 def get_all_transactions(account_name=None, limit=None):
@@ -33,10 +36,17 @@ def add_transaction(*, date, description, amount,
     """Service wrapper around repository insert.
 
     Accepts either ``account_id`` or ``account_name``; one of them must
-    be set (``account_name`` defaults to ``\"Primary Account\"``).
+    be set (``account_name`` defaults to ``"Primary Account"``).
+
+    If no category is provided, deterministically evaluates rules.
     """
     conn = get_db()
     try:
+        # If no category provided, try to apply rules
+        if category is None:
+            rules = get_all_category_rules(conn)
+            category = evaluate_category(description, rules)
+
         return repo_insert_transaction(
             conn,
             date=date,
@@ -50,5 +60,66 @@ def add_transaction(*, date, description, amount,
             account_id=account_id,
             account_name=account_name,
         )
+    finally:
+        conn.close()
+
+
+def apply_category_rules_to_transaction(transaction_id):
+    """Fetch a transaction, evaluate rules against description, update category.
+
+    Pure function of transaction.description + sorted rules.
+    Applies deterministically; no impact to balance, amount, or date.
+    """
+    conn = get_db()
+    try:
+        # Fetch transaction
+        tx = repo_get_transaction_by_id(conn, transaction_id)
+        if not tx:
+            return
+
+        # Extract description
+        description = tx[3]  # description is at index 3 in the SELECT result
+
+        # Fetch rules and evaluate
+        rules = get_all_category_rules(conn)
+        matched_category = evaluate_category(description, rules)
+
+        # Update if match found
+        if matched_category:
+            repo_update_category(conn, transaction_id, matched_category)
+    finally:
+        conn.close()
+
+
+def reclassify_all_transactions():
+    """Re-apply category rules to all transactions deterministically.
+
+    Fetches all transactions, evaluates each against rules in priority order,
+    and updates category if a rule matches.
+
+    Returns count of transactions updated.
+    """
+    conn = get_db()
+    try:
+        # Fetch all transactions
+        transactions = repo_get_all_transactions(conn)
+
+        # Fetch rules once (sorted by priority)
+        rules = get_all_category_rules(conn)
+
+        updated_count = 0
+        for tx in transactions:
+            transaction_id = tx[0]
+            description = tx[3]
+
+            # Deterministically evaluate
+            matched_category = evaluate_category(description, rules)
+
+            # Update if match found
+            if matched_category:
+                repo_update_category(conn, transaction_id, matched_category)
+                updated_count += 1
+
+        return updated_count
     finally:
         conn.close()


### PR DESCRIPTION
## Sprint Proposal

## Sprint Name
Sprint 6 — Category Automation (Deterministic Rule-Based Classification)

## DA Reference
Design Authority v1.1 — Determinism & Layer Separation sections. This PR adheres to the constraints: pure evaluation logic separated from persistence, deterministic outputs, and no direct DB access in pure functions.

## Change Summary
Implements deterministic, rule-based category assignment during ingestion and provides a reclassification endpoint. Key behaviors:
- Auto-assign category for manual and CSV-ingested transactions when `category` is omitted and a rule matches.
- Deterministic evaluation: rules evaluated in stable order (by `id`) using case-insensitive substring matching.
- Administrative endpoint to reclassify all transactions with current rules (`POST /transactions/reclassify`).

## Files Affected
- Added: `services/category_rule_engine.py` (pure evaluator)
- Added: `repositories/category_rules_repository.py` (CRUD for `category_rules`)
- Modified: `services/transaction_service.py` (auto-apply rules in `add_transaction()`, added `apply_category_rules_to_transaction()` and `reclassify_all_transactions()`)
- Modified: `routes/transactions.py` (added POST `/transactions/reclassify`)
- No changes to: forecast, balances, reconciliation, or projection services

## Service Layer Compliance
- All rule evaluation logic is implemented as a pure function (`evaluate_category`) in `services/category_rule_engine.py` with no DB access.
- Persistence and connection management remain in repository/service layers only.
- Routes call service functions; services call repository functions — preserving the DA v1.1 separation.

## Multi-Account Impact
- `add_transaction()` continues to support both `account_id` and `account_name`. Rule evaluation is independent of account; rules may be made account-specific in a future enhancement.

## Determinism Impact
- Deterministic by design: `evaluate_category(description, rules)` is a pure function. Rules are fetched with `ORDER BY id`; therefore the same inputs yield the same outputs. This PR does not alter projection or forecast logic.

## Tier 0 Validation Checklist
- [x] Manual add (category auto-assign when omitted)
- [x] Edit (manual category updates remain supported)
- [x] Delete (no changes to delete behavior)
- [x] CSV import (ingested rows apply same rule logic)
- [x] Reconcile (no changes)
- [x] Safe-to-Spend (no changes)
- [x] Forecast includes recurring items (no changes)

## How to Test (Local)
1. Start the app:
```bash
uvicorn main:app --reload