### PR TITLE
Add configurable forecast window via ?days query parameter

### DIFF
--- a/routes/forecast.py
+++ b/routes/forecast.py
@@ -8,13 +8,14 @@ router = APIRouter()
 
 
 @router.get("/forecast")
-def get_14_day_forecast(as_of_date: Optional[str] = Query(None)):
+def get_forecast(as_of_date: Optional[str] = Query(None), days: int = Query(14, ge=1, le=365)):
     """
-    Return a deterministic 14-day projection of account balances.
+    Return a deterministic N-day projection of account balances.
 
     Query Parameters:
         as_of_date (optional): Reference date in ISO format (YYYY-MM-DD).
                               Defaults to today if not provided.
+        days (optional): Number of days to forecast (default 14, max 365).
 
     Returns:
         ForecastResponseDTO: JSON containing daily balance timeline and Safe-to-Spend.
@@ -32,7 +33,7 @@ def get_14_day_forecast(as_of_date: Optional[str] = Query(None)):
 
     try:
         # Compute projection using deterministic engine
-        projection = calculate_two_week_projection(as_of_date=as_of)
+        projection = calculate_two_week_projection(as_of_date=as_of, days=days)
 
         # Convert to JSON-serializable DTO
         dto = ForecastResponseDTO.from_projection(projection)

--- a/services/projection_service.py
+++ b/services/projection_service.py
@@ -9,15 +9,16 @@ from services.forecast_service import (
 from models.projection_dto import DailyProjection, ProjectionResult
 
 
-def calculate_two_week_projection(as_of_date: Optional[date] = None) -> ProjectionResult:
-    """Deterministic 14-day projection as defined by DA v1.1.
+def calculate_two_week_projection(as_of_date: Optional[date] = None, days: int = 14) -> ProjectionResult:
+    """Deterministic N-day projection as defined by DA v1.1.
 
     Pure function of ledger state, recurring templates, and an optional reference date.
     If ``as_of_date`` is not provided, defaults to ``date.today()``.
+    ``days`` controls the forecast window length (default 14).
     No writes, no side effects, inclusive window definition.
     """
     today = as_of_date if as_of_date is not None else date.today()
-    end_date = today + timedelta(days=14)
+    end_date = today + timedelta(days=days)
 
     # --- starting balance via service/repository chain ---
     txs = get_all_transactions()
@@ -40,7 +41,7 @@ def calculate_two_week_projection(as_of_date: Optional[date] = None) -> Projecti
 
     total_upcoming = 0.0
     for event in events:
-        occurrences = get_occurrences_in_window(event, today, window_days=14)
+        occurrences = get_occurrences_in_window(event, today, window_days=days)
         for occ in occurrences:
             daily_deltas[occ] += event['amount']
             total_upcoming += event['amount']


### PR DESCRIPTION
Previously the forecast was hardcoded to 14 days. Users can now pass ?days=N (1–365) to get any length forecast. Defaults to 14 for backwards compatibility.

# Sprint Proposal

## Sprint Name
-

## DA Reference
(Explicitly cite relevant sections of DESIGN_AUTHORITY.md)

## Change Summary
-

## Files Affected
-

## Service Layer Compliance
(Explain how service layer invariants are preserved)

## Multi-Account Impact
(None / Describe impact)

## Determinism Impact
(Confirm forecast determinism preserved)

## Tier 0 Validation Checklist
- [ ] Manual add
- [ ] Edit
- [ ] Delete
- [ ] CSV import
- [ ] Reconcile
- [ ] Safe-to-Spend
- [ ] Forecast includes recurring items